### PR TITLE
safer check for inconsistent AP data

### DIFF
--- a/aploader/management/commands/initialize_election_date.py
+++ b/aploader/management/commands/initialize_election_date.py
@@ -127,7 +127,8 @@ class Command(BaseCommand):
                 special=(
                     (row["seatnum"] == ("2") and office.body.slug == "senate")
                     or (
-                        "Class II" in row["description"]
+                        # AP has inconsistent data for senate specials for 2018-11-06
+                        "Class II" in row.get("description", "")
                         and office.body.slug == "senate"
                     )
                     or (row["racetype"].startswith("Special"))


### PR DESCRIPTION
While evaluating the Civic tools we noticed that this code fails when running the `initialize_election_date` with current data for 2018/11/06 due to the inconsistent  `description` field in AP response data. 